### PR TITLE
convert label to apiName

### DIFF
--- a/force-app/main/default/classes/Feature.cls
+++ b/force-app/main/default/classes/Feature.cls
@@ -3,10 +3,13 @@ public with sharing class Feature {
     Private Static Map<String, Boolean> FeatureCache = new Map<String, Boolean>(); //Static Map to hold feature flag values as cahed values.
     
     public Static Boolean isActive(String featureName) { //Public function to check the feature flag.
+
         if(FeatureCache.containsKey(featureName)){ 
             return FeatureCache.get(featureName); // Check and return status if the feature is in the cache.
         }
-        Boolean isActive = featureFlag.evaluate(featureName);
+
+        String featureApiName = featureName.normalizeSpace().replace(' ', '_'); //label to api name.
+        Boolean isActive = featureFlag.evaluate(featureApiName);
         
         FeatureCache.put(featureName, isActive); // Write feature flag to the cache.
         return isActive;

--- a/force-app/main/default/classes/FeatureTest.cls
+++ b/force-app/main/default/classes/FeatureTest.cls
@@ -4,11 +4,12 @@ private class FeatureTest {
     @isTest
     private static void testFeature() {
         Feature_Flag__mdt Mockfeature = new Feature_Flag__mdt();
-        Mockfeature.DeveloperName = 'TestFlagTrue';
+        Mockfeature.MasterLabel = 'Test Flag True';
+        Mockfeature.DeveloperName = 'Test_Flag_True';
         Mockfeature.Rollout_Type__c = 'Enabled';
         FeatureFlag.mockedMetadata = Mockfeature;
-        System.AssertEquals(true, Feature.isActive('TestFlagTrue')); //Integration Testing with Mock Data
-        System.AssertEquals(true, Feature.FeatureCache.get('TestFlagTrue')); //Cache Hit Testing
-        System.AssertEquals(true, Feature.featureStatus('TestFlagTrue')); //LWC Function Testing
+        System.AssertEquals(true, Feature.isActive('Test Flag True')); //Integration Testing with Mock Data
+        System.AssertEquals(true, Feature.FeatureCache.get('Test Flag True')); //Cache Hit Testing
+        System.AssertEquals(true, Feature.featureStatus('Test Flag True')); //LWC Function Testing
     }
 }


### PR DESCRIPTION
Issue - When feature label is passed to check status, it returns false due to label vs apiName mismatch
Fix - dynamically convert label to api name